### PR TITLE
Simple optional chaining support

### DIFF
--- a/lib/generate/Request/config.js
+++ b/lib/generate/Request/config.js
@@ -182,8 +182,14 @@ ${aid.indent(pre.join('\n'))}
 
 function renderPost(post) {
   if (post.length) {
+    // TODO REMOVE FIX FOR UNSAFE OPTIONAL CHAINING CONVERSION - ORG CODE
+    // Linked to K6 issue: https://github.com/grafana/k6/issues/2168
+    // return `post(response) {
+// ${aid.indent(post.join('\n'))}
+// }`;
+    // TODO REMOVE FIX FOR UNSAFE OPTIONAL CHAINING CONVERSION - FIX
     return `post(response) {
-${aid.indent(post.join('\n'))}
+${aid.indent(post.join('\n').replace(/\?\.\[/g, '[').replace(/\?\./g, '.'))}
 }`;
   } else {
     return null;


### PR DESCRIPTION
Temporary fix to overcome missing optional chaining support.

Linked to https://github.com/grafana/k6/issues/2168