### PR TITLE
Allows variables that evaluate to falsy to be returned

### DIFF
--- a/lib/shim/core.js
+++ b/lib/shim/core.js
@@ -527,14 +527,23 @@ const pm = Object.freeze({
   /* General variable access */
   variables: Object.freeze({
     get(name) {
-      return (
-        (scope.local[Has](name) && scope.local[name]) ||
-        (scope.data[Has](name) && scope.data[name]) ||
-        (scope.environment[Has](name) && scope.environment[name]) ||
-        (scope.collection[Has](name) && scope.collection[name]) ||
-        (scope.global[Has](name) && scope.global[name]) ||
-        undef
-      );
+      if (scope.local[Has](name)) {
+        return scope.local[name];
+      }
+      if (scope.data[Has](name)) {
+        return scope.data[name];
+      }
+      if (scope.environment[Has](name)) {
+        return scope.environment[name];
+      }
+      if (scope.collection[Has](name)) {
+        return scope.collection[name];
+      }
+      if (scope.global[Has](name)) {
+        return scope.global[name];
+      }
+
+      return undef;
     },
     set(name, value) {
       requireRequest();


### PR DESCRIPTION
The current code skips particular scopes that have a variable defined when the variable is falsy. This is no good as legitimate values such as empty string and boolean 'false' are then skipped and end up being set to undefined.

I'm adding this here as this seem to be an active fork of the original. Hopefully this may be merged back at some point.