### PR TITLE
Extend pm.variables.replaceIn to support Postman variables

### DIFF
--- a/lib/shim/core.js
+++ b/lib/shim/core.js
@@ -550,11 +550,7 @@ const pm = Object.freeze({
       scope.local = scope.local[Write](name, value);
     },
     replaceIn(template) {
-      return template.replace(dynamicGeneratorsRegex, function(match) {
-        // We remove the enclosing {{ }} to extract the generator type like "$randomName"
-        const generatorType = match.slice(2, -2);
-        return dynamicGenerators[generatorType].generator();
-      });
+      return template.replace(expression.variables, (match, name) => pm[Var](name));
     },
   }),
 

--- a/lib/shim/core.js
+++ b/lib/shim/core.js
@@ -550,7 +550,9 @@ const pm = Object.freeze({
       scope.local = scope.local[Write](name, value);
     },
     replaceIn(template) {
-      return template.replace(expression.variables, (match, name) => pm[Var](name));
+      return template.replace(expression.variables, (match, name) =>
+        pm[Var](name)
+      );
     },
   }),
 


### PR DESCRIPTION
This is a follow-up to https://github.com/grafana/postman-to-k6/issues/91

In my postman tests, I am setting 
`pm.environment.set('name', 'somename')`
in one pre-request, and then I use 
`pm.expect(pm.response.json()).eql(pm.variables.replaceIn('{{name}} whatever'))`
in a latter test

The current version of `shim/core.js  pm.variables.replaceIn` only supports dynamic postman `{{$variables}}`, not the `{{simple}}` global/environment/collection ones set up before or during the test.

After reading the `shim/core.js` code, I have come to the conclusion this matches the functionality provided by `shim/core.js evaluate` so I copied the logic from there.

The updated code covers the previous use case, and also provides a simple variable support.
