### PR TITLE
Don't mix ESM and CommonJS in shim/dynamic.js

### DIFF
--- a/lib/shim/dynamic.js
+++ b/lib/shim/dynamic.js
@@ -198,7 +198,7 @@ const DIRECTORY_PATHS = [
 ];
 
 // generators for $random* variables
-const dynamicGenerators = {
+export const dynamicGenerators = {
   // Skipped from Postman
   $guid: {
     description: 'A v4 style guid',
@@ -756,7 +756,7 @@ const dynamicGenerators = {
 // It will look like this: /\{\{\$guid\}\}|\{\{\$timestamp\}\}|\{\{\$isoTimestamp\}\}/g
 // It can then be used to match templates containing generators
 // for example with the replaceIn function
-const dynamicGeneratorsRegex = (function() {
+export const dynamicGeneratorsRegex = (function() {
   let generatorRegexString = '';
   for (const [key, value] of Object.entries(dynamicGenerators)) {
     generatorRegexString += '{{' + key + '}}' + '|';
@@ -770,8 +770,3 @@ const dynamicGeneratorsRegex = (function() {
   const generatorRegex = new RegExp(generatorRegexString, 'g');
   return generatorRegex;
 })();
-
-module.exports = {
-  dynamicGenerators,
-  dynamicGeneratorsRegex,
-};


### PR DESCRIPTION
It seems that at some point when this was written someone mixed ESM and CommonJS syntax.

There is not good reason to do this, and it will soon not be supported - and arguably has never been, it just happened to work due to how ESM was supported in k6.

See https://github.com/grafana/k6/pull/3807 and linked issues/PRs